### PR TITLE
feat: iterate arrays as well

### DIFF
--- a/packages/core/src/__tests__/gen-x.test.ts
+++ b/packages/core/src/__tests__/gen-x.test.ts
@@ -142,11 +142,6 @@ test('strings dont iterate', async () => {
   })
 })
 
-test('arrays dont iterate', async () => {
-  const iterator = genX(() => [1, 2, 3, 4, 5])()
-  expect(await iterator.next()).toEqual({ value: [1, 2, 3, 4, 5], done: false })
-})
-
 test('gen-x', async () => {
   const iterator = genX(
     genX(

--- a/packages/core/src/gen-x.ts
+++ b/packages/core/src/gen-x.ts
@@ -12,11 +12,7 @@ const genX: GenX['genX'] = (...operators: Operator<any, any>[]) =>
         continue
       } else if (isPromise(value)) {
         value = await value
-      } else if (
-        isIterable(value) &&
-        !Array.isArray(value) &&
-        typeof value !== 'string'
-      ) {
+      } else if (isIterable(value) && typeof value !== 'string') {
         const pipe = pipeRest(i, operators)
 
         for (const item of value) {


### PR DESCRIPTION
affects: @gen-x/core

Arrays are also iterable and it turns out it's quite handy to iterate over them.

BREAKING CHANGE:
Will iterate over each item of an array